### PR TITLE
Update README.MD for fix Unit rsyslog.service not found.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,7 +54,7 @@ List of required packages for every script to work
 
 **Debian**
 ``` 
-apt-get install cron gcc systemd autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip bsdmainutils
+apt-get install cron gcc systemd autoconf bc curl diffutils ftp git libflac-dev libssl-dev lm-sensors lynx make mariadb-server ncftp passwd rsync smartmontools tcl tcl-dev tcllib tcl-tls tcpd wget zip bsdmainutils rsyslog
 ``` 
 **BASH** needs to be the default shell. To change from default DASH to BASH in Debian do 
 ``` 


### PR DESCRIPTION
```
Failed to restart rsyslog.service: Unit rsyslog.service not found.

If you are planning to uninstall glFTPd then run cleanup.sh
```